### PR TITLE
Adding missing PyMySQL to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 peewee==2.8.1
 flask
 configargparse
+PyMySQL


### PR DESCRIPTION
Adding MySQLdb as it's a requirement according to the below error :

```
Traceback (most recent call last):
  File "./pgpool.py", line 91, in <module>
    db = init_database(app)
  File "/usr/src/app/pgpool/models.py", line 179, in init_database
    create_tables(db)
  File "/usr/src/app/pgpool/models.py", line 327, in create_tables
    db.connect()
  File "/usr/local/lib/python2.7/site-packages/peewee.py", line 3402, in connect
    **self.connect_kwargs)
  File "/usr/local/lib/python2.7/site-packages/playhouse/pool.py", line 128, in _connect
    conn = super(PooledDatabase, self)._connect(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/peewee.py", line 3921, in _connect
    raise ImproperlyConfigured('MySQLdb or PyMySQL must be installed.')
peewee.ImproperlyConfigured: MySQLdb or PyMySQL must be installed.
```

Tested and confirm it can now connect to my DB.
